### PR TITLE
fix: backslash is not transform when stringify object key

### DIFF
--- a/lib/stringify.js
+++ b/lib/stringify.js
@@ -189,9 +189,11 @@ function stringifyObject(object, replacer, space, indent) {
           str += space ? ',\n' : ',';
         }
 
+        const keyStr = JSON.stringify(key);
+
         str += space
-            ? (childIndent + '"' + key + '": ')
-            : ('"' + key + '":');
+            ? (childIndent + keyStr + ': ')
+            : keyStr + ':';
 
         path[stackIndex] = key;
         str += stringifyValue(value, replacer, space, childIndent);

--- a/test/stringify.test.js
+++ b/test/stringify.test.js
@@ -46,6 +46,16 @@ test('stringify', function (t) {
   t.is(stringify({a:2,b:"str",c:null,d: undefined, e:function() {}}),
       '{"a":2,"b":"str","c":null}', 'should stringify Object');
 
+  t.is(stringify({'\\\\d': 1}),
+      '{\"\\\\\\\\d\":1}',
+      'should stringify a string with control characters');
+
+  // validate exepected outcome against native JSON.stringify
+  t.is(JSON.stringify({'\\\\d': 1}),
+      '{\"\\\\\\\\d\":1}',
+      'should stringify a string with control characters');
+
+
   t.is(stringify({a:2,toJSON: function () {return 'foo'}}),
       '"foo"', 'should stringify object with toJSON method');
 


### PR DESCRIPTION
first, thank you to open source,  and there is a bug,  i found and want to fix it.

like code blow, i execute `stringify` api and `JSON.stringify`, and the arguments is the same, but the result is not the same.
the result of stringify lose four backslash。

so, i modified the code in stringify.js and add unit test to prove it works.

```js
stringify({'\\\\d': 1})
// result "{\"\\\\d\":1}"

JSON.stringify({'\\\\d': 1})
// result "{\"\\\\\\\\d\":1}"
```