### PR TITLE
configure `exports` in `package.json` to fix problem with Jest

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,13 @@
   "browser": "lib/umd/lossless-json.js",
   "types": "lib/types/index.d.ts",
   "sideEffects": false,
+  "exports": {
+    ".": {
+      "import": "./lib/esm/index.js",
+      "require": "./lib/umd/lossless-json.js",
+      "types": "./lib/types/index.d.ts"
+    }
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/josdejong/lossless-json.git"


### PR DESCRIPTION
@josdejong Thank you so much for finding the time to make the transition to ESM. After upgrading, we got some problem running test with `Jest`, the symptom is very similar to what observed in

https://github.com/uuidjs/uuid/issues/451 and https://github.com/uuidjs/uuid/pull/616

In summary,  when `jest-resolve` fail to find `commonjs` bundle and always pick `ESM` bundle. We're still running `Jest` in `non-ESM` mode and I believe a lot of project still do at the moment, so this would be a great help if we could provide a fix.

I have tried the update the `package.json` file to use `exports` and this resolves the problem on my end. Could you find the time to review and release this change?

---

For those who faced the same issue, the workaround is to transform `lossless-json` using `babel-jest` (for example) by excluding from the transform ignore list. 
 