### PR TITLE
feat: make `isSafeNumber` compatible with `Number.isSafeInteger`

### DIFF
--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -56,9 +56,9 @@ test('isSafeNumber', () => {
   expect(isSafeNumber('9007199254740991')).toEqual(true) // Number.MAX_SAFE_INTEGER
   expect(isSafeNumber('9007199254740992')).toEqual(false) // Number.MAX_SAFE_INTEGER + 1
   expect(isSafeNumber('9007199254740993')).toEqual(false) // Number.MAX_SAFE_INTEGER + 2
-  expect(isSafeNumber('-9007199254740991')).toEqual(true) // -Number.MAX_SAFE_INTEGER
-  expect(isSafeNumber('-9007199254740992')).toEqual(false) // -Number.MAX_SAFE_INTEGER + 1
-  expect(isSafeNumber('-9007199254740993')).toEqual(false) // -Number.MAX_SAFE_INTEGER + 2
+  expect(isSafeNumber('-9007199254740991')).toEqual(true) // Number.MIN_SAFE_INTEGER
+  expect(isSafeNumber('-9007199254740992')).toEqual(false) // Number.MIN_SAFE_INTEGER + 1
+  expect(isSafeNumber('-9007199254740993')).toEqual(false) // Number.MIN_SAFE_INTEGER + 2
 })
 
 test('isSafeNumber({ approx: false })', () => {

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -51,6 +51,14 @@ test('isSafeNumber', () => {
 
   // the following number loses formatting, but the value stays the same and hence is safe
   expect(isSafeNumber('2.300')).toEqual(true)
+
+  // test edge cases around MAX_SAFE_INTEGER
+  expect(isSafeNumber('9007199254740991')).toEqual(true) // Number.MAX_SAFE_INTEGER
+  expect(isSafeNumber('9007199254740992')).toEqual(false) // Number.MAX_SAFE_INTEGER + 1
+  expect(isSafeNumber('9007199254740993')).toEqual(false) // Number.MAX_SAFE_INTEGER + 2
+  expect(isSafeNumber('-9007199254740991')).toEqual(true) // -Number.MAX_SAFE_INTEGER
+  expect(isSafeNumber('-9007199254740992')).toEqual(false) // -Number.MAX_SAFE_INTEGER + 1
+  expect(isSafeNumber('-9007199254740993')).toEqual(false) // -Number.MAX_SAFE_INTEGER + 2
 })
 
 test('isSafeNumber({ approx: false })', () => {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -33,6 +33,10 @@ export function isSafeNumber(
     approx: boolean
   }
 ): boolean {
+  if (isInteger(value)) {
+    return Number.isSafeInteger(Number.parseInt(value, 10))
+  }
+
   const num = Number.parseFloat(value)
   const parsed = String(num)
 


### PR DESCRIPTION
See #268 

Pro: compatibility with `Number.isSafeInteger`
Con: 15% less performance
