### PR TITLE
fix: compareNumber treats non-canonical zero (0e5, 0.0) as zero

### DIFF
--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -196,7 +196,11 @@ describe('compareNumber', () => {
     { a: '2000000000000000000000000', b: '2000000000000000000000000', expected: 0 },
     { a: '2000000000000000000000000', b: '2000000000000000000000001', expected: -1 },
     { a: '2000000000000000000000000', b: '200000000000000000000000', expected: 1 },
-    { a: '2000000000000000000000000', b: '1999999999999999999999999', expected: 1 }
+    { a: '2000000000000000000000000', b: '1999999999999999999999999', expected: 1 },
+    { a: '1', b: '0e5', expected: 1 },
+    { a: '0e5', b: '1', expected: -1 },
+    { a: '0', b: '0e5', expected: 0 },
+    { a: '0.0', b: '0', expected: 0 }
   ])('compareNumber($a, $b) -> $expected', ({ a, b, expected }) => {
     expect(compareNumber(a, b)).toEqual(expected)
   })
@@ -204,6 +208,11 @@ describe('compareNumber', () => {
   test('should sort numbers using compareNumber', () => {
     const values = ['4', '2.3', '-2.3', '0.025e2', '-1', '0']
     expect(values.slice().sort(compareNumber)).toEqual(['-2.3', '-1', '0', '2.3', '0.025e2', '4'])
+  })
+
+  test('should sort non-canonical zeros using compareNumber', () => {
+    const values = ['1', '0e5', '2']
+    expect(values.slice().sort(compareNumber)).toEqual(['0e5', '1', '2'])
   })
 })
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -179,11 +179,20 @@ export function compareNumber(a: string, b: string): 1 | 0 | -1 {
 
   const sign: Sign = aa.sign === '-' ? -1 : 1
 
-  if (aa.sign !== bb.sign) {
-    if (aa.digits === '0' && bb.digits === '0') {
+  // treat any zero as zero regardless of its sign or non-canonical exponent (like 0e5 or 0.0),
+  // else comparing against its bogus exponent gives a wrong ordering
+  const aZero = aa.digits === '0'
+  const bZero = bb.digits === '0'
+  if (aZero || bZero) {
+    if (aZero && bZero) {
       return 0
     }
 
+    const bSign: Sign = bb.sign === '-' ? -1 : 1
+    return aZero ? (-bSign as Sign) : sign
+  }
+
+  if (aa.sign !== bb.sign) {
     return sign
   }
 


### PR DESCRIPTION
## Bug

`compareNumber` (and `compareLosslessNumber` built on it) returns the wrong result for any zero written in a non-canonical form.

```js
compareNumber('1', '0e5')   // returns -1, claims 1 < 0
compareNumber('0e5', '1')   // returns 1, claims 0 > 1

[1, 0e5, 2].map(String).sort(compareNumber)
// returns ['1', '2', '0e5'] instead of ['0e5', '1', '2']
```

## Root cause

`splitNumber` does not canonicalize zero: `0` keeps exponent 0, `0.0` keeps exponent -1, and `0e5` keeps exponent 6. `compareNumber` only special-cases zero inside the cross-sign branch. When both values share a sign, it falls through to the exponent comparison and orders zeros by their written (bogus) exponent, so `0e5` sorts as if it were a large number.

## Fix

Short-circuit on zero before the exponent comparison: if a value's mantissa digits are `'0'`, treat it as zero regardless of its written exponent. Two zeros compare equal; a zero against a non-zero is ordered purely by the non-zero value's sign.

## Tests

Added four `compareNumber` cases (`'1'` vs `'0e5'`, `'0e5'` vs `'1'`, `'0'` vs `'0e5'`, `'0.0'` vs `'0'`) and a sort test for `['1', '0e5', '2']`. All existing util tests stay green (65/65 in `utils.test.ts`, 149/149 in the full `src` suite). `npm run lint` is clean.
