### PR TITLE
fix: normalize zero in `splitNumber`, fixing issues comparing non-canonical zero values

### DIFF
--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -147,15 +147,26 @@ describe('splitNumber', () => {
     { value: '-23e3', expected: { sign: '-', digits: '23', exponent: 4 } },
     { value: '2.3e-3', expected: { sign: '', digits: '23', exponent: -3 } },
     { value: '23e-3', expected: { sign: '', digits: '23', exponent: -2 } },
-    { value: '000e+003', expected: { sign: '', digits: '0', exponent: 3 } },
+    { value: '000e+003', expected: { sign: '', digits: '0', exponent: 0 } },
     { value: '-23e-3', expected: { sign: '-', digits: '23', exponent: -2 } },
     { value: '99.99', expected: { sign: '', digits: '9999', exponent: 1 } },
-    { value: '-01200', expected: { sign: '-', digits: '12', exponent: 3 } }
+    { value: '-01200', expected: { sign: '-', digits: '12', exponent: 3 } },
+    { value: '0e5', expected: { sign: '', digits: '0', exponent: 0 } },
+    { value: '0.0', expected: { sign: '', digits: '0', exponent: 0 } },
+    { value: '-0.0', expected: { sign: '', digits: '0', exponent: 0 } },
+    { value: '-0', expected: { sign: '', digits: '0', exponent: 0 } }
   ])('splitNumber($value) -> {sign: $expected.sign, digits: $expected.digits, exponent: $expected.exponent}', ({
     value,
     expected
   }) => {
-    expect(splitNumber(value)).toEqual(expected)
+    const split = splitNumber(value)
+
+    expect(split).toEqual(expected)
+
+    const { sign, digits, exponent } = split
+    const reconstructed = `${sign}${digits[0]}.${digits.slice(1)}e${exponent}`
+
+    expect(parseFloat(reconstructed) === parseFloat(value)).toBe(true)
   })
 
   test('should throw an error when splitting invalid input', () => {
@@ -196,7 +207,11 @@ describe('compareNumber', () => {
     { a: '2000000000000000000000000', b: '2000000000000000000000000', expected: 0 },
     { a: '2000000000000000000000000', b: '2000000000000000000000001', expected: -1 },
     { a: '2000000000000000000000000', b: '200000000000000000000000', expected: 1 },
-    { a: '2000000000000000000000000', b: '1999999999999999999999999', expected: 1 }
+    { a: '2000000000000000000000000', b: '1999999999999999999999999', expected: 1 },
+    { a: '1', b: '0e5', expected: 1 },
+    { a: '0e5', b: '1', expected: -1 },
+    { a: '0', b: '0e5', expected: 0 },
+    { a: '0.0', b: '0', expected: 0 }
   ])('compareNumber($a, $b) -> $expected', ({ a, b, expected }) => {
     expect(compareNumber(a, b)).toEqual(expected)
   })

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -220,6 +220,11 @@ describe('compareNumber', () => {
     const values = ['4', '2.3', '-2.3', '0.025e2', '-1', '0']
     expect(values.slice().sort(compareNumber)).toEqual(['-2.3', '-1', '0', '2.3', '0.025e2', '4'])
   })
+
+  test('should sort non-canonical zeros using compareNumber', () => {
+    const values = ['1', '0e5', '2']
+    expect(values.slice().sort(compareNumber)).toEqual(['0e5', '1', '2'])
+  })
 })
 
 test('countSignificantDigits', () => {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -131,9 +131,14 @@ export function toSafeNumberOrThrow(
 
 /**
  * Split a number into sign, digits, and exponent.
+ * Leading zeros and non-canonical zeros are normalized.
+ *
  * The value can be constructed again from a split number by inserting a dot
  * at the second character of the digits if there is more than one digit,
- * prepending it with the sign, and appending the exponent like `e${exponent}`
+ * prepending it with the sign, and appending an "e" and the exponent as follows:
+ *
+ *     const reconstructed = `${sign}${digits[0]}.${digits.slice(1)}e${exponent}`
+ *
  */
 export function splitNumber(value: string): NumberSplit {
   const match = value.match(/^(-?)(\d+\.?\d*)([eE]([+-]?\d+))?$/)
@@ -157,9 +162,8 @@ export function splitNumber(value: string): NumberSplit {
     })
     .replace(/0*$/, '') // remove trailing zeros
 
-  return digits.length > 0
-    ? { sign, digits, exponent }
-    : { sign, digits: '0', exponent: exponent + 1 }
+  // normalize zero, for example normalizes 0e5 or -0 into 0
+  return digits.length > 0 ? { sign, digits, exponent } : { sign: '', digits: '0', exponent: 0 }
 }
 
 /**

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -184,10 +184,6 @@ export function compareNumber(a: string, b: string): 1 | 0 | -1 {
   const sign: Sign = aa.sign === '-' ? -1 : 1
 
   if (aa.sign !== bb.sign) {
-    if (aa.digits === '0' && bb.digits === '0') {
-      return 0
-    }
-
     return sign
   }
 


### PR DESCRIPTION
Alternative approach to solve #272